### PR TITLE
All metrics names are prefixed with the name of the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Config options:
 |--------|-------------|-----------|---------|
 | uri    | uri of the metrics collector | either this or path | |
 | path   | path to the unix domain socket where the collector is listening | either this or uri ||
-| app    | name of this service or app; meaningful to you | y | |
+| app    | name of this service or app; every metric name will be prefixed with it | y | |
 | node   | name of this specific app instance |  | |
 | maxretries | number of times to retry connecting before giving up |  | 100 |
 | maxbacklog | max number of metrics to hold in backlog during reconnects | | 1000 |
@@ -82,7 +82,7 @@ NOTE: You can of course emit any events you like! The style of events required/e
 
 ### name
 
-String. Required. Name of this event or metric. Use dots `.` to separate namespaces.
+String. Required. Name of this event or metric. Use dots `.` to separate namespaces. If you do not prefix the metric name with `yourapp.`, numbat will do this for you.
 
 ### time
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ var Emitter = require('numbat-emitter');
 
 var emitter = new Emitter({
     uri: 'tcp://localhost:8000',
-    app: 'www-1'
+    app: 'www',
+    node: 'www:8081'
 });
 emitter.metric({ name: 'httpd.latency', value: 30 });
 emitter.metric({ name: 'disk.used.percent', value: 36 });
@@ -24,39 +25,31 @@ See the `examples/` directory for working examples.
 
 The constructor requires an options object with an app name in the `app` field and some manner of specifying where to emit the metrics. You can specify the protocol, host, and port in handy url-parseable format: `tcp://collector.example.com:5000`, `udp://localhost:5000`, `socket:/tmp/foozle.sock`. Do this in the `uri` field of the options object.
 
+Config options:
+
+| option | description | required? | default |
+|--------|-------------|-----------|---------|
+| uri    | uri of the metrics collector | either this or path | |
+| path   | path to the unix domain socket where the collector is listening | either this or uri ||
+| app    | name of this service or app; meaningful to you | y | |
+| node   | name of this specific app instance |  | |
+| maxretries | number of times to retry connecting before giving up |  | 100 |
+| maxbacklog | max number of metrics to hold in backlog during reconnects | | 1000 |
+
+
 An example:
 
 ```javascript
 {
-    uri:  'udp://localhost:8000', // where numbat-collector is running
-    app: 'udp-emitter',  // name of the app emitting metrics; meaningful to you
-    maxretries: 10, // number of times to retry connecting before giving up
-    maxbacklog: 200, // max number of metrics to hold in backlog during reconnects
+    uri:  'udp://localhost:8000',
+    app: 'udp-emitter',
+    node: 'emitter-1',
+    maxretries: 10,
+    maxbacklog: 200,
 }
 ```
 
-You can also specify the destination more verbosely using `host` and `port` fields:
-
-```javascript
-{
-    host: 'collector.example.com',
-    port: 8000,
-    app: 'tcp-emitter'
-}
-```
-
-If you wish to use udp instead of tcp, pass `udp: true`:
-
-```javascript
-{
-    host: 'localhost',
-    port: 8000,
-    udp:  true,
-    app: 'udp-emitter'
-}
-```
-
-And finally a unix domain socket:
+Or numbat might be listening via a unix domain socket:
 
 ```javascript
 {

--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -27,6 +27,7 @@ var Emitter = module.exports = function Emitter(opts)
 	this.defaults = {};
 	this.defaults.host = os.hostname();
 	this.defaults.app = opts.app;
+	this.defaults.node = opts.node;
 	this.backlog = [];
 	this.output = new JSONOutputStream();
 

--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -14,7 +14,6 @@ var Emitter = module.exports = function Emitter(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object to the Emitter constructor');
 	assert((opts.host && opts.port) || opts.path || opts.uri, 'you must pass uri, path, or a host/port pair for the collector');
-	if (opts.node && !opts.app) opts.app = opts.node;
 	assert(opts.app && _.isString(opts.app), 'you must pass an `app` option naming this service or app');
 
 	events.EventEmitter.call(this);
@@ -24,10 +23,12 @@ var Emitter = module.exports = function Emitter(opts)
 	if (opts.maxbacklog) this.maxbacklog = parseInt(opts.maxbacklog, 10);
 
 	this.options = opts;
-	this.defaults = {};
-	this.defaults.host = os.hostname();
-	this.defaults.app = opts.app;
-	this.defaults.node = opts.node;
+	this.defaults =
+	{
+		host: os.hostname(),
+		node: opts.node,
+	};
+	this.app = opts.app;
 	this.backlog = [];
 	this.output = new JSONOutputStream();
 
@@ -143,6 +144,9 @@ Emitter.prototype.makeEvent = function makeEvent(attrs)
 {
 	assert(attrs && _.isObject(attrs), 'you cannot make an empty event');
 	assert(attrs.name, 'you must give your metric a name');
+
+	if (this.app && attrs.name.indexOf(this.app) !== 0)
+		attrs.name = this.app + '.' + attrs.name;
 
 	var event = {};
 	_.defaults(event, attrs, this.defaults);

--- a/test.js
+++ b/test.js
@@ -16,13 +16,15 @@ describe('numbat-emitter', function()
 	{
 		host: 'localhost',
 		port: 4333,
-		app: 'node-1'
+		app: 'testapp',
+		node: 'node-1'
 	};
 
 	var mockUDPOpts =
 	{
 		uri: 'udp://localhost:4334',
-		app: 'node-1'
+		app: 'testapp',
+		node: 'node-1'
 	};
 
 	var mockServer, mockUDPServer;
@@ -143,18 +145,6 @@ describe('numbat-emitter', function()
 
 			emitter.destroy();
 			done();
-		});
-
-		it('uses a node option as the app option if it must', function()
-		{
-			var emitter = new Emitter(
-			{
-				uri: 'udp://localhost:4334',
-				node: 'node-1'
-			});
-
-			emitter.defaults.must.have.property('app');
-			emitter.defaults.app.must.equal('node-1');
 		});
 
 		it('calls parseURI() when given a uri option', function()
@@ -287,9 +277,10 @@ describe('numbat-emitter', function()
 				d.must.be.an.object();
 				d.must.have.property('host');
 				d.must.have.property('time');
-				d.must.have.property('app');
-				d.app.must.equal('node-1');
+				d.must.have.property('node');
+				d.node.must.equal('node-1');
 				d.value.must.equal(4);
+				d.name.must.equal('testapp.test');
 				mockServer.removeListener('received', observer);
 				done();
 			}
@@ -329,7 +320,7 @@ describe('numbat-emitter', function()
 				emitter.backlog.must.be.an.array();
 				emitter.backlog.length.must.equal(2);
 				emitter.backlog[0].must.have.property('name');
-				emitter.backlog[0].name.must.equal('test.splort');
+				emitter.backlog[0].name.must.equal('testapp.test.splort');
 
 				done();
 			});
@@ -348,11 +339,11 @@ describe('numbat-emitter', function()
 			{
 				count++;
 				if (count === 1)
-					d.name.must.equal('test.splort');
+					d.name.must.equal('testapp.test.splort');
 
 				if (count === 2)
 				{
-					d.name.must.equal('test.latency');
+					d.name.must.equal('testapp.test.latency');
 					mockServer.removeListener('received', observer);
 					done();
 				}
@@ -379,8 +370,8 @@ describe('numbat-emitter', function()
 			var emitter = new Emitter(mockOpts);
 			emitter.on('ready', function()
 			{
-				emitter.metric({ name: 'test.splort', value: 4 });
-				emitter.metric({ name: 'test.latency', value: 30 });
+				emitter.metric({ name: 'testapp.splort', value: 4 });
+				emitter.metric({ name: 'testapp.latency', value: 30 });
 			});
 
 			var count = 0;
@@ -390,10 +381,10 @@ describe('numbat-emitter', function()
 				switch (count)
 				{
 				case 1:
-					d.name.must.equal('test.splort');
+					d.name.must.equal('testapp.splort');
 					break;
 				case 2:
-					d.name.must.equal('test.latency');
+					d.name.must.equal('testapp.latency');
 					mockServer.removeListener('received', observer);
 					done();
 					break;


### PR DESCRIPTION
If you supply `node`, we'll add it to every metric. If you don't, we won't.

Updated tests & documentation to match.