### PR TITLE
switch to discard-stream

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -1,13 +1,14 @@
 var
-	_         = require('lodash'),
-	assert    = require('assert'),
-	events    = require('events'),
-	net       = require('net'),
-	os        = require('os'),
 	stream    = require('readable-stream'),
+	discard   = require('discard-stream'),
 	UDPStream = require('./udp-stream'),
+	_         = require('lodash'),
+	events    = require('events'),
+	assert    = require('assert'),
+	util      = require('util'),
 	url       = require('url'),
-	util      = require('util')
+	net       = require('net'),
+	os        = require('os')
 ;
 
 var Emitter = module.exports = function Emitter(opts)
@@ -29,21 +30,27 @@ var Emitter = module.exports = function Emitter(opts)
 		node: opts.node,
 	};
 	this.app = opts.app;
-	this.backlog = [];
-	this.output = new JSONOutputStream();
-
+	this.input = discard({objectMode: true, maxBacklog: opts.maxbacklog});
+	this.output = createSerializer();
+	this.input.pipe(this.output);
 	this.connect();
 };
 util.inherits(Emitter, events.EventEmitter);
 
 Emitter.prototype.defaults = null;
-Emitter.prototype.backlog  = null;
 Emitter.prototype.maxbacklog = 1000;
 Emitter.prototype.client   = null;
 Emitter.prototype.ready    = false;
 Emitter.prototype.retries  = 0;
 Emitter.prototype.maxretries = 100;
 Emitter.prototype.maxbacklog = 1000;
+
+Object.defineProperty(Emitter.prototype, 'backlog', {
+	get: function()
+	{
+		return this.input.backlog;
+	}
+});
 
 Emitter.parseURI = function(options)
 {
@@ -110,10 +117,8 @@ Emitter.prototype.destroy = function destroy()
 	this.client = null;
 };
 
-Emitter.prototype.onConnect = function onConnect()
+Emitter.prototype.onConnect = function onConnect(err)
 {
-	while (this.backlog.length)
-		this._write(this.backlog.shift());
 	this.retries = 0;
 	this.ready = true;
 	this.emit('ready');
@@ -156,37 +161,27 @@ Emitter.prototype.makeEvent = function makeEvent(attrs)
 	return event;
 };
 
-Emitter.prototype._write = function _write(event, encoding, callback)
-{
-	var payload = event;
-	if (_.isObject(event))
-		payload = JSON.stringify(event) + '\n';
-
-	this.output.write(payload);
-};
-
 Emitter.prototype.metric = function metric(attrs)
 {
-	var event = this.makeEvent(attrs);
-	if (this.ready)
-		this._write(event);
-	else
-		this.backlog.push(event);
-
-	while (this.backlog.length > this.maxbacklog)
-		this.backlog.shift();
+	attrs = typeof attrs === 'string' ? 
+		{ name: attrs } : attrs;
+	this.input.write(this.makeEvent(attrs));
 };
 
-function JSONOutputStream()
+function createSerializer()
 {
-	stream.Transform.call(this);
-	this._readableState.objectMode = false;
-	this._writableState.objectMode = true;
+	var opts =
+	{
+		readableObjectMode: false,
+		writableObjectMode: true,
+		highWaterMark: 0
+	};
+	var transformer = new stream.Transform(opts)
+
+	transformer._transform = function (chunk, enc, ready)
+	{
+		return ready(null, JSON.stringify(chunk) + '\n')
+	}
+
+	return transformer
 }
-util.inherits(JSONOutputStream, stream.Transform);
-
-JSONOutputStream.prototype._transform = function _transformOut(object, encoding, callback)
-{
-	this.push(object);
-	callback();
-};

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     }
   },
   "dependencies": {
-    "json-stream": "~1.0.0",
+    "discard-stream": "^1.0.1",
     "lodash": "~3.10.1",
     "readable-stream": "~2.0.1"
   },
   "devDependencies": {
+    "json-stream": "~1.0.0",
     "blanket": "~1.1.7",
     "jscs": "~2.0.0",
     "jshint": "~2.8.0",


### PR DESCRIPTION
discard-stream accounts for the buffering mechanics of streams2 — preventing the possibility of the underlying output stream buffering writes in an unbound fashion.

I tried to preserve the old `.backlog` property — it's now generated, and exposes the `.backlog` property of the discard-stream.